### PR TITLE
use password_hash() for password hash instead of plain md5

### DIFF
--- a/controllers/MemberController.php
+++ b/controllers/MemberController.php
@@ -5,12 +5,12 @@ namespace Ecdb\Controllers;
 class MemberController extends BaseController {
 
     private function inPasswordValid($member_id, $password) {
-        $data = $this->db->fetchAssoc('SELECT COUNT(*) AS c FROM members WHERE member_id = ? AND passwd = ?', array(
+        $passwordHash = $this->db->fetchColumn('SELECT passwd FROM members WHERE member_id = ?', array(
             $member_id,
-            md5($password),
         ));
 
-        return !empty($data['c']);
+        $validatePassword = $this->app->getContainer()->get('validatePassword');
+        return $validatePassword($password, $passwordHash);
     }
 
     public function edit(\Slim\Http\Request $req, \Slim\Http\Response $response, $args) {
@@ -61,12 +61,11 @@ class MemberController extends BaseController {
                     'firstname' => $firstname,
                     'lastname' => $lastname,
                     'mail' => $mail,
-                    'passwd' => md5($newpass),
                     'measurement' => $measurement,
                     'currency' => $currency,
                 );
                 if ($oldpass && $newpass) {
-                    $data['passwd'] = md5($newpass);
+                    $data['passwd'] = password_hash($newpass, PASSWORD_BCRYPT);
                 }
                 $login = $this->db->fetchColumn('SELECT login from members where member_id = ?', array(
                     $_SESSION['SESS_MEMBER_ID'],
@@ -101,7 +100,7 @@ class MemberController extends BaseController {
 
         $this->view->assign('selected_menu', 'my');
 
-        return $this->view->display('member.tpl');
+        return $this->render('member.tpl');
     }
 
 }

--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -80,13 +80,15 @@ class RegisterController extends BaseController {
             return $this->render('registration.tpl');
         }
 
+        $passwordHash = password_hash($_POST['password'], PASSWORD_BCRYPT);
+
         //Create INSERT query
         $added = $this->db->insert('members', array(
             'firstname' => $fname,
             'lastname' => $lname,
             'login' => $login,
             'mail' => $mail,
-            'passwd' => md5($_POST['password']),
+            'passwd' => $passwordHash,
         ));
 
         $_SESSION['messages'][] = 'User created';

--- a/include/dependencies.php
+++ b/include/dependencies.php
@@ -58,6 +58,15 @@ $container['view'] = function ($container) use ($ECDB_VERSION, $config) {
 
     return $smarty;
 };
+$container['validatePassword'] = function ($container) use ($app) {
+    return function ($password, $passwordHash) {
+        if (strlen($passwordHash) == 32) {
+            return md5($password) == $passwordHash;
+        }
+
+        return password_verify($password, $passwordHash);
+    };
+};
 
 $container['db'] = function ($container) use ($config) {
     $c = new \Doctrine\DBAL\Configuration();

--- a/sql/migrations/Version20171114200630.php
+++ b/sql/migrations/Version20171114200630.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace EcdbMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+class Version20171114200630 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+
+        /**
+         * member password
+         */
+        $this->addSql('ALTER TABLE members MODIFY passwd VARCHAR(100) NOT NULL');
+
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        /**
+         * member password
+         */
+        $this->addSql('ALTER TABLE members MODIFY passwd VARCHAR(32) NOT NULL');
+
+    }
+}


### PR DESCRIPTION
Passwords in DB were stored as plain MD5 hash (without salt). Switched to [`password_hash()`](http://php.net/manual/en/function.password-hash.php) to store password hashes and avoid finding out passwords using rainbow table.

Existing password hashes will be regenerated after first successful login. New users will get new password hashes.